### PR TITLE
Solo.io isn't supported in Credly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,17 +48,6 @@ Calico is a networking and security solution for containers, virtual machines, a
 
 1. [Certified Calico Operator - eBPF](https://academy.tigera.io/course/certified-calico-operator-ebpf/)
 
-## Solo.io [Need help to verify]
-![Alt text](images/Solo.jpg?raw=true "Solo Logo")
-[Solo.io](https://www.solo.io/) is the leading provider of API gateway, service mesh, & internal developer portal solutions. Solo.io develops innovative cloud-native solutions.
-They offer five free courses where you can earn digital badges. Click [here](https://www.solo.io/academy/) to visit their Academy landing page, where they claim to provide certificates.
-
-1. [Envoy Basics](https://academy.solo.io/learn/courses/81/envoy-basics)
-2. [Service Mesh Basics](https://academy.solo.io/learn/courses/80/service-mesh-basics)
-3. [API Gateway Basics](https://academy.solo.io/learn/courses/79/api-gateway-basics)
-4. [Cilium CNI Basics](https://academy.solo.io/learn/courses/78/cilium-cni-basics)
-5. [Istio Basics](https://academy.solo.io/learn/courses/77/istio-basics)
-
 ## AWS
 ![Alt text](images/aws.png?raw=true "AWS")
 


### PR DESCRIPTION
Solo.io issues private badges hosted exclusively on their platform.

<img width="1355" alt="Screenshot 2024-12-04 at 11 21 39 AM" src="https://github.com/user-attachments/assets/0c267ce5-6f35-4a75-9b06-d44bd49bc16f">

Istio certs are only given by 4 orgs
<img width="605" alt="Screenshot 2024-12-04 at 11 25 10 AM" src="https://github.com/user-attachments/assets/e5e84406-96ca-47ff-ae5a-09dcd9e8cc4c">

No mentions of Solo on Credly
<img width="1034" alt="Screenshot 2024-12-04 at 11 25 28 AM" src="https://github.com/user-attachments/assets/86c24f29-b817-4a14-a0b9-2e92b845440b">
